### PR TITLE
Channel importer + purpose

### DIFF
--- a/resource_channel.go
+++ b/resource_channel.go
@@ -22,6 +22,12 @@ func resourceChannel() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 21),
 			},
 
+			"channel_purpose": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Sets the purpose for a channel",
+				Optional:    true,
+			},
+
 			"channel_topic": &schema.Schema{
 				Type:        schema.TypeString,
 				Description: "Sets the topic for a channel",
@@ -45,6 +51,10 @@ func resourceChannelCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(channel.ID)
 
+	// Update Slack Channel Purpose
+	if _, err := api.SetChannelPurpose(d.Id(), d.Get("channel_purpose").(string)); err != nil {
+		return err
+	}
 	// Create Slack Channel Topic
 	if _, err := api.SetChannelTopic(channel.ID, d.Get("channel_topic").(string)); err != nil {
 		return err
@@ -71,6 +81,10 @@ func resourceChannelUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("channel_name").(string)
 	if _, err := api.RenameChannel(d.Id(), name); err != nil {
+		return err
+	}
+	// Update Slack Channel Purpose
+	if _, err := api.SetChannelPurpose(d.Id(), d.Get("channel_purpose").(string)); err != nil {
 		return err
 	}
 	// Update Slack Channel Topic

--- a/resource_channel.go
+++ b/resource_channel.go
@@ -73,6 +73,10 @@ func resourceChannelUpdate(d *schema.ResourceData, meta interface{}) error {
 	if _, err := api.RenameChannel(d.Id(), name); err != nil {
 		return err
 	}
+	// Update Slack Channel Topic
+	if _, err := api.SetChannelTopic(d.Id(), d.Get("channel_topic").(string)); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
This adds an import option to the `slack_channel` resource, as well as supporting the channel's `purpose` property.

As a side note, it will be good to rebuild the provider so it can pick up Terraform 0.12 support.