### PR TITLE
Bump channel name limit from 21 to 80 chars

### DIFF
--- a/resource_channel.go
+++ b/resource_channel.go
@@ -22,7 +22,7 @@ func resourceChannel() *schema.Resource {
 				Type:         schema.TypeString,
 				Description:  "The name of Slack Channel that will be created",
 				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 21),
+				ValidateFunc: validation.StringLenBetween(1, 80),
 			},
 
 			"channel_purpose": &schema.Schema{


### PR DESCRIPTION
80 characters are now supported for Slack channel names - https://slackhq.com/new-slack-features-search-calls-channels