### PR TITLE
Increase channel name length limit from 21 to 80

### DIFF
--- a/resource_channel.go
+++ b/resource_channel.go
@@ -22,7 +22,7 @@ func resourceChannel() *schema.Resource {
 				Type:         schema.TypeString,
 				Description:  "The name of Slack Channel that will be created",
 				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 21),
+				ValidateFunc: validation.StringLenBetween(1, 80),
 			},
 
 			"channel_purpose": &schema.Schema{


### PR DESCRIPTION
...since they have increased the limit in Aug'19.
https://slackhq.com/new-slack-features-search-calls-channels
> If Game of Thrones can have more than 21 characters, then so can our channels. We’re extending the maximum length of channel names—from 21 to a whopping 80 characters. That means acronym-packed channels can finally be written out. It helps channel names become a little more clear—and a lot more human.